### PR TITLE
update random password generation

### DIFF
--- a/btcp_store_demo.sh
+++ b/btcp_store_demo.sh
@@ -89,7 +89,7 @@ fi
 if [ ! -e ~/.btcprivate/btcprivate.conf ]
 then
 
-local RPCPASSWORD=$(head -c 32 /dev/urandom | base64)
+local RPCPASSWORD=$(openssl rand -base64 32 | tr -d /=+ | cut -c -30)
 touch ~/.btcprivate/btcprivate.conf
 cat << EOF > ~/.btcprivate/btcprivate.conf
 #gen=1


### PR DESCRIPTION
update random password generation to not include /=+

for this https://github.com/ch4ot1c/bitcore-install/blob/master/btcp_store_demo.sh#L92 I suggest

`local RPCPASSWORD=$(openssl rand -base64 32 | tr -d /=+ | cut -c -30)`